### PR TITLE
make GMT within docker container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,5 +24,5 @@ WORKDIR /home/hc_user
 
 RUN git clone 'https://github.com/geodynamics/hc'; curl -L -O https://github.com/GenericMappingTools/gmt/releases/download/4.5.18/gmt-4.5.18-src.tar.bz2;
 ENV GMT4HOME="/home/hc_user/gmt-4.5.18"
-RUN tar -xvf gmt-4.5.18-src.tar.bz2; cd gmt-4.5.18; ./configure; make install-gmt; cd ..; cd hc; make all;
+RUN tar -xvf gmt-4.5.18-src.tar.bz2; cd gmt-4.5.18; ./configure; make; make install-gmt; cd ..; cd hc; make all;
 ENV PATH="/home/hc_user/hc/bin:${PATH}"


### PR DESCRIPTION
Previously, the dockerfile only ran make install-gmt while building the container. This allowed hc to compile but did not let the user run any GMT scripts which might let them plot hc results within the container. I added the "make" command to the dockerfile so that it is possible to run command line gmt scripts in the container.